### PR TITLE
Fixed nexus context mapping

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+.gradle/
+.idea/
+build/

--- a/src/main/groovy/com/simplifyops/rundeck/plugin/nexus/NexusHttpRequestHandler.groovy
+++ b/src/main/groovy/com/simplifyops/rundeck/plugin/nexus/NexusHttpRequestHandler.groovy
@@ -1,0 +1,56 @@
+package com.simplifyops.rundeck.plugin.nexus
+
+import com.dtolabs.rundeck.core.execution.workflow.steps.FailureReason
+import com.dtolabs.rundeck.core.execution.workflow.steps.StepException
+import groovyx.net.http.HTTPBuilder
+import groovyx.net.http.Method
+import groovyx.net.http.URIBuilder
+import groovyx.net.http.ContentType
+
+
+class NexusHttpRequestHandler {
+
+    static final String REDIRECT_URL = "/service/local/artifact/maven/redirect"
+
+    public static enum Reason implements FailureReason {
+        FileNotFound, UnexepectedFailure
+    }
+
+    static handleRequest(host, user, password, query, successHandler) {
+
+        def uri = new URIBuilder(host + REDIRECT_URL).setQuery(query);
+
+        println "Nexus request URL: ${uri}"
+
+        def http = new HTTPBuilder(uri)
+
+        if (user && password) {
+            http.auth.basic user, password
+        }
+
+        http.request( Method.GET, ContentType.ANY ) {
+
+            response.success = successHandler
+
+            response.failure = { resp ->
+                throw new StepException("Status code: ${resp.status}. query: ${query}. server: ${host}", Reason.UnexepectedFailure)
+            }
+
+            response.'404' = { resp ->
+                throw new StepException("Artifact not found in matching query: ${query}, server: ${host}", Reason.FileNotFound)
+            }
+        }
+    }
+
+    static buildQuery(group , artifact, version, repo, packaging, classifier) {
+
+        def query = [g: group, a: artifact, v: version, r: repo, p: packaging]
+
+        if (classifier) {
+            query.c = classifier
+        }
+
+        return query
+    }
+
+}

--- a/src/main/groovy/com/simplifyops/rundeck/plugin/nexus/NexusRegisterArtifactDeliveryStepPlugin.groovy
+++ b/src/main/groovy/com/simplifyops/rundeck/plugin/nexus/NexusRegisterArtifactDeliveryStepPlugin.groovy
@@ -39,6 +39,8 @@ import com.dtolabs.rundeck.plugins.step.PluginStepContext
 import com.dtolabs.rundeck.plugins.step.StepPlugin
 import groovyx.net.http.URIBuilder
 
+import static com.simplifyops.rundeck.plugin.nexus.NexusHttpRequestHandler.REDIRECT_URL
+
 /**
  * Example Req  http://192.168.50.20:8081/nexus/service/local/artifact/maven/redirect?r=releases&g=sardine&a=sardine&v=5.0&p=jar
  */
@@ -74,19 +76,13 @@ public class NexusRegisterArtifactDeliveryStepPlugin implements StepPlugin {
     private String nexus;
 
 
-    static final String REDIRECT_URL = "/service/local/artifact/maven/redirect"
-
-
 
     @Override
     public void executeStep(final PluginStepContext context, final Map<String, Object> configuration)
     throws StepException {
 
 
-        def query = [g: group, a: artifact, v: version, r: repo, p: packaging]
-        if (classifier) {
-            query.c = classifier
-        }
+        def query = NexusHttpRequestHandler.buildQuery(group, artifact, version, repo, packaging, classifier)
 
         String customDestinationPath = destinationPath;
 
@@ -119,8 +115,7 @@ public class NexusRegisterArtifactDeliveryStepPlugin implements StepPlugin {
             newNode.setAttribute("${prefix}:groupId", group)
             newNode.setAttribute("${prefix}:artifactId", artifact)
             newNode.setAttribute("${prefix}:destination_path", expandedPath)
-            newNode.setAttribute("${prefix}:repoUrl", new URIBuilder(nexus)
-                    .setPath(REDIRECT_URL)
+            newNode.setAttribute("${prefix}:repoUrl", new URIBuilder(nexus + REDIRECT_URL)
                     .setQuery(query)
                     .toString())
 


### PR DESCRIPTION
The `HTTPBuilder` truncated the `/nexus` servlet context path.
Now the `NexusHttpRequestHandler.handleRequest` will respect the context path (if provided)